### PR TITLE
Update neo4j.properties

### DIFF
--- a/scripts/NeoConfig/neo4j.properties
+++ b/scripts/NeoConfig/neo4j.properties
@@ -71,7 +71,7 @@ ha.server=xthis_server_ip:6001
 
 # The interval at which slaves will pull updates from the master. Comment out
 # the option to disable periodic pulling of updates. Unit is seconds.
-#ha.pull_interval=10
+ha.pull_interval=10
 
 # Amount of slaves the master will try to push a transaction to upon commit
 # (default is 1). The master will optimistically continue and not fail the
@@ -98,4 +98,4 @@ ha.server=xthis_server_ip:6001
 #ha.heartbeat_interval=5s
 
 # Timeout for heartbeats between cluster members. Should be at least twice that of ha.heartbeat_interval.
-#heartbeat_timeout=11s
+#ha.heartbeat_timeout=11s


### PR DESCRIPTION
Uncomment "ha.pull_interval=10", as the default is 0, which is bad news.

Also edit the last line as the default config file has a mistake, and in case someone wants to uncomment this value, it is better to have the setting correct. "heartbeat_timeout=11s" should read "ha.heartbeat_timeout=11s"
